### PR TITLE
Support allowed and rejected previous statuses

### DIFF
--- a/src/main/java/seatsio/events/Events.java
+++ b/src/main/java/seatsio/events/Events.java
@@ -384,7 +384,10 @@ public class Events {
     }
 
     public List<ChangeObjectStatusResult> changeObjectStatus(List<StatusChangeRequest> statusChangeRequests) {
-        List<JsonElement> statusChangeRequestsAsJson = statusChangeRequests.stream().map(s -> changeObjectStatusRequest(s.eventKey, toObjects(s.objects), s.status, s.holdToken, s.orderId, s.keepExtraData, s.ignoreChannels, s.channelKeys, null)).collect(toList());
+        List<JsonElement> statusChangeRequestsAsJson = statusChangeRequests
+                .stream()
+                .map(s -> changeObjectStatusRequest(s.eventKey, toObjects(s.objects), s.status, s.holdToken, s.orderId, s.keepExtraData, s.ignoreChannels, s.channelKeys, null, s.allowedPreviousStatuses, s.rejectedPreviousStatuses))
+                .collect(toList());
         JsonObject request = aJsonObject()
                 .withProperty("statusChanges", aJsonArray().withItems(statusChangeRequestsAsJson).build())
                 .build();
@@ -406,10 +409,12 @@ public class Events {
                 .collect(toList());
     }
 
-    private JsonObject changeObjectStatusRequest(String eventKey, List<ObjectProperties> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing) {
+    private JsonObject changeObjectStatusRequest(String eventKey, List<ObjectProperties> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
         JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing);
         request.withProperty("event", eventKey);
         request.withProperty("objects", objects, object -> gson().toJsonTree(object));
+        request.withPropertyIfNotNull("allowedPreviousStatuses", allowedPreviousStatuses);
+        request.withPropertyIfNotNull("rejectedPreviousStatuses", rejectedPreviousStatuses);
         return request.build();
     }
 

--- a/src/main/java/seatsio/events/Events.java
+++ b/src/main/java/seatsio/events/Events.java
@@ -376,10 +376,21 @@ public class Events {
         return changeObjectStatus(singletonList(eventKey), objects, status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing);
     }
 
+    public ChangeObjectStatusResult changeObjectStatus(String eventKey, List<?> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
+        return changeObjectStatus(singletonList(eventKey), objects, status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing, allowedPreviousStatuses, rejectedPreviousStatuses);
+    }
+
     public ChangeObjectStatusResult changeObjectStatus(List<String> eventKeys, List<?> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing) {
         String response = unirest.stringResponse(UnirestWrapper.post(baseUrl + "/events/groups/actions/change-object-status")
                 .queryString("expand", "objects")
-                .body(changeObjectStatusRequest(eventKeys, toObjects(objects), status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing).toString()));
+                .body(changeObjectStatusRequest(eventKeys, toObjects(objects), status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing, null, null).toString()));
+        return gson().fromJson(response, ChangeObjectStatusResult.class);
+    }
+
+    public ChangeObjectStatusResult changeObjectStatus(List<String> eventKeys, List<?> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
+        String response = unirest.stringResponse(UnirestWrapper.post(baseUrl + "/events/groups/actions/change-object-status")
+                .queryString("expand", "objects")
+                .body(changeObjectStatusRequest(eventKeys, toObjects(objects), status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing, allowedPreviousStatuses, rejectedPreviousStatuses).toString()));
         return gson().fromJson(response, ChangeObjectStatusResult.class);
     }
 
@@ -410,28 +421,26 @@ public class Events {
     }
 
     private JsonObject changeObjectStatusRequest(String eventKey, List<ObjectProperties> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
-        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing);
+        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing, allowedPreviousStatuses, rejectedPreviousStatuses);
         request.withProperty("event", eventKey);
         request.withProperty("objects", objects, object -> gson().toJsonTree(object));
-        request.withPropertyIfNotNull("allowedPreviousStatuses", allowedPreviousStatuses);
-        request.withPropertyIfNotNull("rejectedPreviousStatuses", rejectedPreviousStatuses);
         return request.build();
     }
 
-    private JsonObject changeObjectStatusRequest(List<String> eventKeys, List<ObjectProperties> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing) {
-        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing);
+    private JsonObject changeObjectStatusRequest(List<String> eventKeys, List<ObjectProperties> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
+        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, ignoreSocialDistancing, allowedPreviousStatuses, rejectedPreviousStatuses);
         request.withProperty("events", eventKeys);
         request.withProperty("objects", objects, object -> gson().toJsonTree(object));
         return request.build();
     }
 
     private JsonObject changeObjectStatusRequest(BestAvailable bestAvailable, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys) {
-        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, null);
+        JsonObjectBuilder request = changeObjectStatusRequestBuilder(status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, null, null, null);
         request.withProperty("bestAvailable", gson().toJsonTree(bestAvailable));
         return request.build();
     }
 
-    private JsonObjectBuilder changeObjectStatusRequestBuilder(String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing) {
+    private JsonObjectBuilder changeObjectStatusRequestBuilder(String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Boolean ignoreSocialDistancing, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
         return aJsonObject()
                 .withProperty("status", status)
                 .withPropertyIfNotNull("holdToken", holdToken)
@@ -439,7 +448,9 @@ public class Events {
                 .withPropertyIfNotNull("keepExtraData", keepExtraData)
                 .withPropertyIfNotNull("ignoreChannels", ignoreChannels)
                 .withPropertyIfNotNull("channelKeys", channelKeys)
-                .withPropertyIfNotNull("ignoreSocialDistancing", ignoreSocialDistancing);
+                .withPropertyIfNotNull("ignoreSocialDistancing", ignoreSocialDistancing)
+                .withPropertyIfNotNull("allowedPreviousStatuses", allowedPreviousStatuses)
+                .withPropertyIfNotNull("rejectedPreviousStatuses", rejectedPreviousStatuses);
     }
 
     public EventObjectInfo retrieveObjectInfo(String key, String label) {

--- a/src/main/java/seatsio/events/StatusChangeRequest.java
+++ b/src/main/java/seatsio/events/StatusChangeRequest.java
@@ -15,12 +15,18 @@ public class StatusChangeRequest extends ValueObject {
     public final Boolean keepExtraData;
     public final Boolean ignoreChannels;
     public final Set<String> channelKeys;
+    public final Set<String> allowedPreviousStatuses;
+    public final Set<String> rejectedPreviousStatuses;
 
     public StatusChangeRequest(String eventKey, List<?> objects, String status) {
-        this(eventKey, objects, status, null, null, null, null, null);
+        this(eventKey, objects, status, null, null, null, null, null, null, null);
     }
 
     public StatusChangeRequest(String eventKey, List<?> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys) {
+        this(eventKey, objects, status, holdToken, orderId, keepExtraData, ignoreChannels, channelKeys, null, null);
+    }
+
+    public StatusChangeRequest(String eventKey, List<?> objects, String status, String holdToken, String orderId, Boolean keepExtraData, Boolean ignoreChannels, Set<String> channelKeys, Set<String> allowedPreviousStatuses, Set<String> rejectedPreviousStatuses) {
         this.eventKey = eventKey;
         this.objects = objects;
         this.status = status;
@@ -29,5 +35,7 @@ public class StatusChangeRequest extends ValueObject {
         this.keepExtraData = keepExtraData;
         this.ignoreChannels = ignoreChannels;
         this.channelKeys = channelKeys;
+        this.allowedPreviousStatuses = allowedPreviousStatuses;
+        this.rejectedPreviousStatuses = rejectedPreviousStatuses;
     }
 }

--- a/src/test/java/seatsio/events/ChangeObjectStatusForMultipleEventsTest.java
+++ b/src/test/java/seatsio/events/ChangeObjectStatusForMultipleEventsTest.java
@@ -1,8 +1,10 @@
 package seatsio.events;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 import seatsio.SeatsioClientTest;
+import seatsio.SeatsioException;
 import seatsio.charts.SocialDistancingRuleset;
 import seatsio.holdTokens.HoldToken;
 
@@ -12,6 +14,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ChangeObjectStatusForMultipleEventsTest extends SeatsioClientTest {
 
@@ -90,6 +93,37 @@ public class ChangeObjectStatusForMultipleEventsTest extends SeatsioClientTest {
 
         assertThat(client.events.retrieveObjectInfo(event1.key, "A-1").status).isEqualTo(EventObjectInfo.BOOKED);
         assertThat(client.events.retrieveObjectInfo(event2.key, "A-1").status).isEqualTo(EventObjectInfo.BOOKED);
+    }
+
+
+    @Test
+    public void allowedPreviousStatuses() {
+        String chartKey = createTestChart();
+        Event event1 = client.events.create(chartKey);
+        Event event2 = client.events.create(chartKey);
+
+        try {
+            client.events.changeObjectStatus(asList(event1.key, event2.key), newArrayList("A-1"), EventObjectInfo.BOOKED, null, null, null, null, null, true, Sets.newHashSet("MustBeThisStatus"), null);
+            fail("expected exception");
+        } catch (SeatsioException e) {
+            assertThat(e.errors).hasSize(1);
+            assertThat(e.errors.get(0).getCode()).isEqualTo("ILLEGAL_STATUS_CHANGE");
+        }
+    }
+
+    @Test
+    public void rejectedPreviousStatuses() {
+        String chartKey = createTestChart();
+        Event event1 = client.events.create(chartKey);
+        Event event2 = client.events.create(chartKey);
+
+        try {
+            client.events.changeObjectStatus(asList(event1.key, event2.key), newArrayList("A-1"), EventObjectInfo.BOOKED, null, null, null, null, null, true, null, Sets.newHashSet("free"));
+            fail("expected exception");
+        } catch (SeatsioException e) {
+            assertThat(e.errors).hasSize(1);
+            assertThat(e.errors.get(0).getCode()).isEqualTo("ILLEGAL_STATUS_CHANGE");
+        }
     }
 
 }


### PR DESCRIPTION
Note: this is backwards compatible, I only added new methods. 