### PR TITLE
Fix for InaccessibleObjectException on JDK 17 (when running without Gradle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Then you can refer to seatsio-java as a regular package:
 ```
 // build.gradle
 dependencies {
-  compile 'com.github.seatsio:seatsio-java:73.0.0'
+  compile 'com.github.seatsio:seatsio-java:73.1.0'
 }
 
 // pom.xml
 <dependency>
   <groupId>com.github.seatsio</groupId>
   <artifactId>seatsio-java</artifactId>
-  <version>73.0.0</version>
+  <version>73.1.0</version>
 </dependency>
 ```
 

--- a/src/main/java/seatsio/SeatsioException.java
+++ b/src/main/java/seatsio/SeatsioException.java
@@ -35,7 +35,7 @@ public class SeatsioException extends RuntimeException {
 
     public static SeatsioException from(HttpRequest request, RawResponse response, byte[] responseBody) {
         if (response.getHeaders().getFirst("Content-Type").contains("application/json")) {
-            SeatsioException parsedException = fromJson(responseBody);
+            SeatsioExceptionTO parsedException = fromJson(responseBody);
             if (response.getStatus() == 429) {
                 return new RateLimitExceededException(parsedException.errors, parsedException.requestId, request, response);
             }
@@ -55,7 +55,14 @@ public class SeatsioException extends RuntimeException {
         return request.getHttpMethod() + " " + request.getUrl() + " resulted in a " + response.getStatus() + " " + response.getStatusText() + " response.";
     }
 
-    private static SeatsioException fromJson(byte[] responseBody) {
-        return gson().fromJson(new String(responseBody, UTF_8), SeatsioException.class);
+    private static SeatsioExceptionTO fromJson(byte[] responseBody) {
+        return gson().fromJson(new String(responseBody, UTF_8), SeatsioExceptionTO.class);
+    }
+
+    private static class SeatsioExceptionTO {
+
+        public List<ApiError> errors;
+        public String requestId;
+
     }
 }


### PR DESCRIPTION
On JDK 17, processing error responses fails:

```
Caused by: com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
	at com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:38)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:287)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130)
	at com.google.gson.Gson.getAdapter(Gson.java:546)
	at com.google.gson.Gson.fromJson(Gson.java:1213)
	at com.google.gson.Gson.fromJson(Gson.java:1124)
	at com.google.gson.Gson.fromJson(Gson.java:1034)
	at com.google.gson.Gson.fromJson(Gson.java:969)
	at seatsio.SeatsioException.fromJson(SeatsioException.java:59)
	at seatsio.SeatsioException.from(SeatsioException.java:38)
	at seatsio.util.UnirestWrapper.processResponse(UnirestWrapper.java:54)
	at seatsio.util.UnirestWrapper.execute(UnirestWrapper.java:41)
	at seatsio.util.UnirestWrapper.stringResponse(UnirestWrapper.java:24)
	at seatsio.charts.Charts.retrieve(Charts.java:32)
	at seatsio.ErrorHandlingTest.lambda$test400$0(ErrorHandlingTest.java:12)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:53)
	... 41 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private java.lang.String java.lang.Throwable.detailMessage accessible: module java.base does not "opens java.lang" to unnamed module @462d5aee
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:35)
	... 56 more
```

Unfortunately, our tests don't fail. Gradle adds `--add-opens` options to the JVM because it does reflection magic itself. There seems to be no way around that: https://github.com/gradle/gradle/issues/18671

I tested manually however, and the error is gone with this PR.