### PR TITLE
added scripts to automate releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,6 @@ on:
         options:
           - minor
           - major
-      releaseNotes:
-        description: 'Release notes'
-        required: true
-        type: string
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,8 +28,7 @@ jobs:
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
           chmod +x /usr/local/bin/semver
-      - run: zx ./release.mjs -v $VERSION_TO_BUMP -n "$RELEASE_NOTES"
+      - run: zx ./release.mjs -v $VERSION_TO_BUMP
         env:
           VERSION_TO_BUMP: ${{ inputs.versionToBump }}
-          RELEASE_NOTES: ${{ inputs.releaseNotes }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+# Very important!
+# Make sure that the github token has read AND WRITE access on github.
+#   1. hit https://github.com/seatsio/[REPO]/settings/actions
+#   2. under "Workflow permissions", make sure "Read and write permissions" is checked instead of the (default?) read only.
+#
+
+name: Release
+run-name: Release ${{ github.repository }}
+on:
+  workflow_dispatch:
+    inputs:
+      versionToBump:
+        description: 'The version to bump. Major for incompatible API changes, minor for adding BC features'
+        required: true
+        type: choice
+        options:
+          - minor
+          - major
+      releaseNotes:
+        description: 'Release notes'
+        required: true
+        type: string
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: fregante/setup-git-user@v2
+      - id: install-zx
+        run: npm i -g zx
+      - id: install-semver-tool
+        run: |
+          wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+          chmod +x /usr/local/bin/semver
+      - run: zx ./release.mjs -v $VERSION_TO_BUMP -n "$RELEASE_NOTES"
+        env:
+          VERSION_TO_BUMP: ${{ inputs.versionToBump }}
+          RELEASE_NOTES: ${{ inputs.releaseNotes }}
+          GH_TOKEN: ${{ github.token }}

--- a/release.mjs
+++ b/release.mjs
@@ -20,7 +20,6 @@
 $.verbose = false
 
 const versionToBump = getVersionToBump()
-const releaseNotes = getReleaseNotes()
 const latestVersion = await fetchLatestReleasedVersionNumber()
 const nextVersion = await determineNextVersionNumber(latestVersion)
 
@@ -34,12 +33,6 @@ function getVersionToBump() {
         throw new Error ("Please specify -v major/minor")
     }
     return argv.v
-}
-function getReleaseNotes() {
-    if (!argv.n) {
-        throw new Error("Please provide release notes using -n notes")
-    }
-    return argv.n;
 }
 
 function removeLeadingV(tagName) {
@@ -94,7 +87,7 @@ async function commitAndPush() {
 
 async function release() {
     const newTag = 'v' + nextVersion
-    return await $`gh release create ${newTag} -n ${releaseNotes}`.catch(error => {
+    return await $`gh release create ${newTag} --generate-notes`.catch(error => {
         console.error('something went wrong while creating the release. Please revert the version change!')
         throw error
     })

--- a/release.mjs
+++ b/release.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env zx
+
+/*
+* Script to release the seats.io java lib.
+*   - changes the version number in README.md
+*   - changes the version number in build.gradle
+*   - creates the release in Gihub (using gh cli)
+*
+*
+* Prerequisites:
+*   - zx installed (https://github.com/google/zx)
+*   - gh cli installed (https://cli.github.com/)
+*   - semver cli installed (https://github.com/fsaintjacques/semver-tool)
+*
+* Usage:
+*   zx ./release.mjs -v major/minor -n "release notes"
+* */
+
+// don't output the commands themselves
+$.verbose = false
+
+const versionToBump = getVersionToBump()
+const releaseNotes = getReleaseNotes()
+const latestVersion = await fetchLatestReleasedVersionNumber()
+const nextVersion = await determineNextVersionNumber(latestVersion)
+
+await pullLastVersion()
+    .then(bumpVersionInFiles)
+    .then(commitAndPush)
+    .then(release)
+
+function getVersionToBump() {
+    if (!argv.v || !(argv.v === 'minor' || argv.v === 'major')) {
+        throw new Error ("Please specify -v major/minor")
+    }
+    return argv.v
+}
+function getReleaseNotes() {
+    if (!argv.n) {
+        throw new Error("Please provide release notes using -n notes")
+    }
+    return argv.n;
+}
+
+function removeLeadingV(tagName) {
+    if (tagName.startsWith('v')) {
+        return tagName.substring(1)
+    }
+    return tagName
+}
+
+async function fetchLatestReleasedVersionNumber() {
+    let result = await $`gh release view --json tagName`
+    let tagName = JSON.parse(result).tagName
+    return removeLeadingV(tagName)
+}
+
+async function determineNextVersionNumber(previous) {
+    return (await $`semver bump ${versionToBump} ${previous}`).stdout.trim()
+}
+
+async function bumpVersionInFiles() {
+    await replaceInFile("README.md", `seatsio-java:${latestVersion}`, `seatsio-java:${nextVersion}`)
+    await replaceInFile("README.md", `<version>${latestVersion}</version>`, `<version>${nextVersion}</version>`)
+    await replaceInFile("build.gradle", `version = '${latestVersion}'`, `version = '${nextVersion}'`)
+}
+
+async function replaceInFile(filename, latestVersion, nextVersion) {
+    return await fs.readFile(filename, 'utf8')
+        .then(text => {
+            if (text.indexOf(latestVersion) < 0) {
+                throw new Error('Not the correct version. Could not find ' + latestVersion + ' in ' + filename)
+            }
+            return text
+        })
+        .then(text => text.replace(latestVersion, nextVersion))
+        .then(text => fs.writeFileSync(filename, text))
+        .then(() => gitAdd(filename))
+}
+
+async function pullLastVersion() {
+    await $`git checkout master`
+    await $`git pull origin master`
+}
+
+async function gitAdd(filename) {
+    return await $`git add ${filename}`
+}
+
+async function commitAndPush() {
+    await $`git commit -m "version bump"`
+    await $`git push origin master`
+}
+
+async function release() {
+    const newTag = 'v' + nextVersion
+    return await $`gh release create ${newTag} -n ${releaseNotes}`.catch(error => {
+        console.error('something went wrong while creating the release. Please revert the version change!')
+        throw error
+    })
+}

--- a/releasing.md
+++ b/releasing.md
@@ -1,5 +1,4 @@
 *Note: this is internal documentation for the seats.io team*
 
-1) Set the correct version number in README.md (2 places)
-2) Set the correct version number in build.gradle
-3) Create the release in GitHub
+1) Head over to https://github.com/seatsio/seatsio-java/actions/workflows/release.yml
+2) Use the "run workflow" button


### PR DESCRIPTION
Makes it easy to release the java client lib (We can use this for all other client libs as well of course)

<img width="361" alt="Screenshot 2023-03-15 at 11 59 52" src="https://user-images.githubusercontent.com/686092/225289614-5c65c784-4a56-461b-b3e8-a416e6d5d8fe.png">


