### PR TITLE
Remove update chart key for event

### DIFF
--- a/src/main/java/seatsio/events/Events.java
+++ b/src/main/java/seatsio/events/Events.java
@@ -88,7 +88,6 @@ public class Events {
 
     public void update(String key, UpdateEventParams params) {
         JsonObjectBuilder request = aJsonObject()
-                .withPropertyIfNotNull("chartKey", params.chartKey)
                 .withPropertyIfNotNull("eventKey", params.eventKey)
                 .withPropertyIfNotNull("name", params.name)
                 .withPropertyIfNotNull("date", params.date == null ? null : gson().toJsonTree(params.date))

--- a/src/main/java/seatsio/events/UpdateEventParams.java
+++ b/src/main/java/seatsio/events/UpdateEventParams.java
@@ -2,13 +2,7 @@ package seatsio.events;
 
 public class UpdateEventParams extends EventParams<UpdateEventParams> {
 
-    public String chartKey;
     public Boolean isInThePast;
-
-    public UpdateEventParams withChartKey(String chartKey) {
-        this.chartKey = chartKey;
-        return this;
-    }
 
     public UpdateEventParams withIsInThePast(Boolean isInThePast) {
         this.isInThePast = isInThePast;

--- a/src/test/java/seatsio/events/UpdateEventTest.java
+++ b/src/test/java/seatsio/events/UpdateEventTest.java
@@ -5,34 +5,17 @@ import seatsio.SeatsioClientTest;
 import seatsio.charts.Category;
 import seatsio.charts.CategoryKey;
 import seatsio.charts.Chart;
-import seatsio.seasons.Season;
 import seatsio.seasons.SeasonParams;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
-import static java.time.Instant.now;
-import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static seatsio.events.TableBookingMode.BY_SEAT;
 import static seatsio.events.TableBookingMode.BY_TABLE;
 
 public class UpdateEventTest extends SeatsioClientTest {
-
-    @Test
-    public void updateChartKey() {
-        Chart chart1 = client.charts.create();
-        Event event = client.events.create(chart1.key);
-        Chart chart2 = client.charts.create();
-
-        client.events.update(event.key, new UpdateEventParams().withChartKey(chart2.key));
-
-        Event retrievedEvent = client.events.retrieve(event.key);
-        assertThat(retrievedEvent.key).isEqualTo(event.key);
-        assertThat(retrievedEvent.chartKey).isEqualTo(chart2.key);
-        assertThat(retrievedEvent.updatedOn).isBetween(now().minus(1, MINUTES), now().plus(1, MINUTES));
-    }
 
     @Test
     public void updateEventKey() {
@@ -150,7 +133,7 @@ public class UpdateEventTest extends SeatsioClientTest {
     @Test
     public void updateIsInThePast() {
         String chartKey = createTestChart();
-        Season season = client.seasons.create(chartKey, new SeasonParams().eventKeys(List.of("event1")));
+        client.seasons.create(chartKey, new SeasonParams().eventKeys(List.of("event1")));
         Event event = client.events.retrieve("event1");
         assertThat(event.isInThePast).isFalse();
 


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `UpdateEventParams`.