### PR TITLE
distinct exception type thrown when best available objects not found

### DIFF
--- a/src/main/java/seatsio/SeatsioException.java
+++ b/src/main/java/seatsio/SeatsioException.java
@@ -2,6 +2,7 @@ package seatsio;
 
 import kong.unirest.HttpRequest;
 import kong.unirest.RawResponse;
+import seatsio.events.BestAvailableObjectsNotFoundException;
 import seatsio.exceptions.RateLimitExceededException;
 
 import java.util.List;
@@ -38,6 +39,8 @@ public class SeatsioException extends RuntimeException {
             SeatsioExceptionTO parsedException = fromJson(responseBody);
             if (response.getStatus() == 429) {
                 return new RateLimitExceededException(parsedException.errors, parsedException.requestId);
+            } else if (parsedException.errors.stream().anyMatch(e -> e.getCode().equals("BEST_AVAILABLE_OBJECTS_NOT_FOUND"))) {
+                return new BestAvailableObjectsNotFoundException(parsedException.errors, parsedException.requestId);
             }
             return new SeatsioException(parsedException.errors, parsedException.requestId);
         }

--- a/src/main/java/seatsio/SeatsioException.java
+++ b/src/main/java/seatsio/SeatsioException.java
@@ -39,12 +39,16 @@ public class SeatsioException extends RuntimeException {
             SeatsioExceptionTO parsedException = fromJson(responseBody);
             if (response.getStatus() == 429) {
                 return new RateLimitExceededException(parsedException.errors, parsedException.requestId);
-            } else if (parsedException.errors.stream().anyMatch(e -> e.getCode().equals("BEST_AVAILABLE_OBJECTS_NOT_FOUND"))) {
+            } else if (isBestAvailableObjectsNotFound(parsedException)) {
                 return new BestAvailableObjectsNotFoundException(parsedException.errors, parsedException.requestId);
             }
             return new SeatsioException(parsedException.errors, parsedException.requestId);
         }
         return new SeatsioException(request, response);
+    }
+
+    private static boolean isBestAvailableObjectsNotFound(SeatsioExceptionTO parsedException) {
+        return parsedException.errors.stream().anyMatch(e -> "BEST_AVAILABLE_OBJECTS_NOT_FOUND".equals(e.getCode()));
     }
 
     private static String exceptionMessage(List<ApiError> errors) {

--- a/src/main/java/seatsio/events/BestAvailableObjectsNotFoundException.java
+++ b/src/main/java/seatsio/events/BestAvailableObjectsNotFoundException.java
@@ -1,0 +1,13 @@
+package seatsio.events;
+
+import seatsio.ApiError;
+import seatsio.SeatsioException;
+
+import java.util.List;
+
+public class BestAvailableObjectsNotFoundException extends SeatsioException {
+
+    public BestAvailableObjectsNotFoundException(List<ApiError> errors, String requestId) {
+        super(errors, requestId);
+    }
+}


### PR DESCRIPTION
Instead of throwing a generic `SeatsioException` (which is thrown in many cases, eg no focal point, event not found, etc), we now throw a `BestAvailableObjectsNotFoundException` (subclass of `SeatsioException`) to make it easier to handle this common specific case. 